### PR TITLE
Adicionado o retorno da função quando o tipo do Field for um TGUID

### DIFF
--- a/Source/DB/AqDrop.DB.FD.pas
+++ b/Source/DB/AqDrop.DB.FD.pas
@@ -1049,6 +1049,7 @@ begin
     case pField.DataType of
       ftString, ftFmtMemo, ftFixedChar, ftWideString, ftFixedWideChar, ftWideMemo:
         Result := TAqGUIDFunctions.FromRawString(pField.AsString);
+      ftGuid: Result := pField.AsGuid;
     else
       raise EAqFDUnexpectedFieldType.Create(pField.DataType, TypeInfo(Currency), pField.FieldName);
     end;


### PR DESCRIPTION
Resolve o problema quando efetua um Get em uma classe que possua um Field do tipo TGUID.